### PR TITLE
Update test for upcoming tmap v4

### DIFF
--- a/tests/testthat/test-stateMap.R
+++ b/tests/testthat/test-stateMap.R
@@ -54,7 +54,11 @@ testthat::test_that("handles errors correctly", {
 testthat::test_that("subsets by stateCode correctly", {
 
   stateCodeList <- c('WA', 'OR')
-  plottedStates <- stateMap(example_US_stateObesity, 'obesityRate', stateCode = stateCodeList)$tm_shape$shp$stateCode
+  if (packageVersion("tmap") >= "3.99.9002") {
+      plottedStates <- stateMap(example_US_stateObesity, 'obesityRate', stateCode = stateCodeList)[[1]]$shp$stateCode
+  } else {
+      plottedStates <- stateMap(example_US_stateObesity, 'obesityRate', stateCode = stateCodeList)$tm_shape$shp$stateCode
+  }
 
   testthat::expect_equal(length(plottedStates), length(stateCodeList))
   testthat::expect_true('WA' %in% plottedStates)


### PR DESCRIPTION
tmap will soon release its version 4.0, which is a complete overhaul of the package.

Some of tmap internal objects will change due to this, which makes MazamaSpatialPlots fail.

This PR makes sure that MazamaSpatialPlots tests pass with CRAN tmap (3.3.4) and upcoming tmap v4

If possible, a CRAN release would be great!

cc @mtennekes https://github.com/r-tmap/tmap/issues/908 

Feel free to do more testing of your package with dev tmap (installable with `pak::pak("r-tmap/tmap")` and report back if something is not working as expected.